### PR TITLE
fix(angular-query): improve development workflow

### DIFF
--- a/packages/angular-query-devtools-experimental/package.json
+++ b/packages/angular-query-devtools-experimental/package.json
@@ -45,5 +45,11 @@
   },
   "peerDependencies": {
     "@angular/core": "^17"
+  },
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/fesm2022/tanstack-angular-query-devtools-experimental.mjs"
+    }
   }
 }

--- a/packages/angular-query-experimental/package.json
+++ b/packages/angular-query-experimental/package.json
@@ -16,9 +16,6 @@
   },
   "type": "module",
   "sideEffects": false,
-  "types": "build/esm2022/index.d.ts",
-  "main": "build/esm2022/index.mjs",
-  "module": "build/esm2022/index.mjs",
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
@@ -50,5 +47,11 @@
   },
   "peerDependencies": {
     "@angular/core": "^17"
+  },
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/fesm2022/tanstack-angular-query-experimental.mjs"
+    }
   }
 }


### PR DESCRIPTION
This seems to fix multiple issues while developing the adapter and will result in the same published package as before: exports field will be overwritten by ng-packagr